### PR TITLE
Remove broken command to allow bootstrap to continue unperturbed.

### DIFF
--- a/vagrant_vm/bootstrap.sh
+++ b/vagrant_vm/bootstrap.sh
@@ -61,7 +61,7 @@ boost_func(){
 
 hello_func
 openjdk7_func
-eclipse_func
+#eclipse_func XXX: broken url
 
 g++_func
 git_func


### PR DESCRIPTION
The link we currently use to fetch the eclipse binary is broken. I'm in favor of just not installing it by default. It seemed to get little use last semester, and it's quite a large download with a ton of dependencies. It can be installed if needed with the following command:

`sudo apt-get install eclipse`