### PR TITLE
Add global gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# emacs files
+
+*~
+\#*\#
+
+# vim files
+
+.*.swp
+
+# generated C/C++ files
+
+a.out
+*.o
+*.gch
+*.a
+*.so
+*.dylib
+
+# generated build system files
+
+cmake_install.cmake
+CMakeCache.txt
+CMakeFiles/
+
+# generated java files
+
+*.class


### PR DESCRIPTION
Prevents accidental commits of files that should not be committed. Even if we have .gitignore files in the assignment directories, files related to editors (or anything else, I suppose) may sneak into source control via activity outside of those directories and lazy use of `git commit -a`.